### PR TITLE
Add send/receive message example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@ SystemLink Client API Examples
 ==============================
 
 This directory holds self-contained example projects for various aspects of the
-SystemLink client APIs. To make finding relevant examples easier, a summary of
+SystemLink Client APIs. To make finding relevant examples easier, a summary of
 each one is listed below.
 
 Running an Example
@@ -25,15 +25,19 @@ dotnet run -- --server <url> <username> <password>
 
 For example: `dotnet run -- --server https://my_server admin "my password"`.
 
-Examples
---------
+Common Examples
+---------------
 
-### Common
+The following examples demonstrate concepts common across all SystemLink Client
+APIs:
 
-- [configuration](configuration): Demonstrates the different ways to
-  supply a configuration for SystemLink APIs.
+- [configuration](configuration): Demonstrates the different ways to supply a
+  configuration for SystemLink APIs.
+
+API Examples
+------------
 
 ### [Message](message)
 
 - [Send and Receive](message/send_receive): Demonstrates how to use the
-  SystemLink Message client API to send and receive messages between sessions
+  SystemLink Message Client API to send and receive messages between sessions

--- a/examples/message/README.md
+++ b/examples/message/README.md
@@ -2,10 +2,10 @@ SystemLink Message Client API Examples
 ======================================
 
 This directory holds self-contained example projects for the SystemLink Message
-client API. To make finding relevant examples easier, a summary of each one is
+Client API. To make finding relevant examples easier, a summary of each one is
 listed below.
 
-Examples for other SystemLink client APIs are available in the
+Examples for other SystemLink Client APIs are available in the
 [root examples directory](..).
 
 Running an Example
@@ -32,4 +32,4 @@ Message Examples
 ----------------
 
 - [Send and Receive](send_receive): Demonstrates how to use the
-  SystemLink Message client API to send and receive messages between sessions
+  SystemLink Message Client API to send and receive messages between sessions

--- a/examples/message/README.md
+++ b/examples/message/README.md
@@ -1,9 +1,12 @@
-SystemLink Client API Examples
-==============================
+SystemLink Message Client API Examples
+======================================
 
-This directory holds self-contained example projects for various aspects of the
-SystemLink client APIs. To make finding relevant examples easier, a summary of
-each one is listed below.
+This directory holds self-contained example projects for the SystemLink Message
+client API. To make finding relevant examples easier, a summary of each one is
+listed below.
+
+Examples for other SystemLink client APIs are available in the
+[root examples directory](..).
 
 Running an Example
 ------------------
@@ -25,15 +28,8 @@ dotnet run -- --server <url> <username> <password>
 
 For example: `dotnet run -- --server https://my_server admin "my password"`.
 
-Examples
---------
+Message Examples
+----------------
 
-### Common
-
-- [configuration](configuration): Demonstrates the different ways to
-  supply a configuration for SystemLink APIs.
-
-### [Message](message)
-
-- [Send and Receive](message/send_receive): Demonstrates how to use the
+- [Send and Receive](send_receive): Demonstrates how to use the
   SystemLink Message client API to send and receive messages between sessions

--- a/examples/message/send_receive/README.md
+++ b/examples/message/send_receive/README.md
@@ -24,6 +24,19 @@ dotnet run -- --server <url> <username> <password>
 
 For example: `dotnet run -- --server https://my_server admin "my password"`.
 
+### Sample output
+
+```
+Opening message read session...
+Publishing messages...
+Message queue size: 138 of 1048576 bytes
+Reading back messages...
+Received message Hello World! PI=3.14159265358979
+Received message Another message, E=2.71828182845905
+Received exit message first exit
+Remaining bytes in the message queue: 11
+```
+
 About the Example
 -----------------
 

--- a/examples/message/send_receive/README.md
+++ b/examples/message/send_receive/README.md
@@ -2,9 +2,9 @@ Message Send and Receive Example
 ================================
 
 This is a simple example console application demonstrating how to use the
-SystemLink Message client API to send and receive messages between sessions.
+SystemLink Message Client API to send and receive messages between sessions.
 
-Additional message client examples are available in the
+Additional message Client examples are available in the
 [root message examples directory](..).
 
 Running the Example

--- a/examples/message/send_receive/README.md
+++ b/examples/message/send_receive/README.md
@@ -1,0 +1,70 @@
+Message Send and Receive Example
+================================
+
+This is a simple example console application demonstrating how to use the
+SystemLink Message client API to send and receive messages between sessions.
+
+Additional message client examples are available in the
+[root message examples directory](..).
+
+Running the Example
+-------------------
+
+1. Download and extract the [repository source](https://github.com/ni/systemlink-client-docs/archive/master.zip).
+2. Install the [.NET Core SDK](https://dotnet.microsoft.com/download/dotnet-core).
+3. Navigate to the example's directory and use the [`dotnet run` command](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-run?tabs=netcore21).
+
+To run the example with a different configuration, use one of the following
+commands instead:
+
+```
+dotnet run -- --cloud <api_key>
+dotnet run -- --server <url> <username> <password>
+```
+
+For example: `dotnet run -- --server https://my_server admin "my password"`.
+
+About the Example
+-----------------
+
+This example creates two message sessions. From one session, it publishes both
+JSON data messages and a control message. From the other session, it subscribes
+and then reads the published messages.
+
+### Message Sessions and Queues
+
+A message session represents a queue for receiving messages published by other
+sessions connected to the same SystemLink Server or SystemLink Cloud instance.
+Each session receives its own copy of messages, allowing 1 to N communication
+between applications, potentially running on different systems.
+
+### Topics and Subscriptions
+
+Every published message includes a topic, which is a simple, usually short,
+string identifying the type of data contained in the message or the intended
+type of recipient. For example, applications may use one topic for sending
+control messages to systems and another for issuing status updates. Sessions
+must subscribe to a topic before it receives any messages for that topic. When
+unsubscribing from a topic, messages that are already queued but not yet read
+are dropped.
+
+Sessions are not required to subscribe to any topics if they are only used for
+publishing messages. A session that publishes a message to a topic it is also
+subscribed to will receive a copy of its own message.
+
+### Reading Messages
+
+When a session receives a message to a subscribed topic, it is queued on the
+server. Applications must read from the session in order to dequeue a message
+from the server. When reading a message from an empty queue, the API call will
+block up to a given amount of time waiting for a message before eventually
+returning null to indicate the queue is empty.
+
+### Message Session Limits
+
+Both SystemLink Cloud and SystemLink Server define a maximum number of message
+sessions that may be open at a time. The server will automatically close idle
+sessions that neither publish nor read messages after a few minutes.
+Additionally, SystemLink Cloud has a maximum number of queued bytes per session
+before received messages are dropped. For SystemLink Server, this maximum is
+disabled by default, but system administrators can set a maximum.

--- a/examples/message/send_receive/SendReceive.cs
+++ b/examples/message/send_receive/SendReceive.cs
@@ -22,8 +22,8 @@ namespace NationalInstruments.SystemLink.Clients.Examples.Message
 
             /*
              * Open a session and subscribe to a couple of topics. Once
-             * subscribed, the server will queue messages published to any of
-             * these topics until read.
+             * subscribed, the server will begin to queue messages published
+             * these topics. They remain queued until read by the session.
              */
             Console.WriteLine("Opening message read session...");
 
@@ -31,7 +31,6 @@ namespace NationalInstruments.SystemLink.Clients.Examples.Message
             {
                 readSession.Subscribe("example.data");
                 readSession.Subscribe("example.exit");
-                PublishMessages(configuration);
 
                 /*
                  * The read session will receive all messages for the the
@@ -41,6 +40,7 @@ namespace NationalInstruments.SystemLink.Clients.Examples.Message
                  * between the message being published and it being queued and
                  * available for reading.
                  */
+                PublishMessages(configuration);
                 Console.WriteLine("Message queue size: {0} of {1} bytes",
                    readSession.QueueSize, readSession.MaxQueueSize);
                 Console.WriteLine("Reading back messages...");
@@ -49,9 +49,9 @@ namespace NationalInstruments.SystemLink.Clients.Examples.Message
                 while (!receivedExitMessage)
                 {
                     /*
-                     * Blocks on the server until a message is available in the
-                     * queue or a brief amount of time has passed. Returns null
-                     * when there are no queued messages.
+                     * Blocks until a message is available in the queue or a
+                     * brief amount of time has passed. Returns null when there
+                     * are no queued messages.
                      */
                     var message = readSession.Read();
                     receivedExitMessage = HandleMessage(message);

--- a/examples/message/send_receive/SendReceive.cs
+++ b/examples/message/send_receive/SendReceive.cs
@@ -7,8 +7,8 @@ namespace NationalInstruments.SystemLink.Clients.Examples.Message
 {
     /// <summary>
     /// Example for the SystemLink Message client API that opens two message
-    /// sessions, sends JSON messages from one, then reads those messages back
-    /// from the other.
+    /// sessions, sends JSON messages from one, and then reads those messages
+    /// back from the other.
     /// </summary>
     class SendReceive
     {
@@ -23,7 +23,7 @@ namespace NationalInstruments.SystemLink.Clients.Examples.Message
             /*
              * Open a session and subscribe to a couple of topics. Once
              * subscribed, the server will begin to queue messages published
-             * these topics. They remain queued until read by the session.
+             * to these topics. They remain queued until read by the session.
              */
             Console.WriteLine("Opening message read session...");
 

--- a/examples/message/send_receive/SendReceive.cs
+++ b/examples/message/send_receive/SendReceive.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using NationalInstruments.SystemLink.Clients.Core;
+using NationalInstruments.SystemLink.Clients.Message;
+using Newtonsoft.Json;
+
+namespace NationalInstruments.SystemLink.Clients.Examples.Message
+{
+    /// <summary>
+    /// Example for the SystemLink Message client API that opens two message
+    /// sessions, sends JSON messages from one, then reads those messages back
+    /// from the other.
+    /// </summary>
+    class SendReceive
+    {
+        static void Main(string[] args)
+        {
+            /*
+             * See the configuration example for how a typical application
+             * might obtain a configuration.
+             */
+            var configuration = ExampleConfiguration.Obtain(args);
+
+            /*
+             * Open a session and subscribe to a couple of topics. Once
+             * subscribed, the server will queue messages published to any of
+             * these topics until read.
+             */
+            Console.WriteLine("Opening message read session...");
+
+            using (var readSession = MessageSession.Open(configuration))
+            {
+                readSession.Subscribe("example.data");
+                readSession.Subscribe("example.exit");
+                PublishMessages(configuration);
+
+                /*
+                 * The read session will receive all messages for the the
+                 * subscribed topics, but not the message for the unknown
+                 * topic. The messages are read in order they are queued on the
+                 * server regardless of topic. There may be a small delay
+                 * between the message being published and it being queued and
+                 * available for reading.
+                 */
+                Console.WriteLine("Message queue size: {0} of {1} bytes",
+                   readSession.QueueSize, readSession.MaxQueueSize);
+                Console.WriteLine("Reading back messages...");
+                bool receivedExitMessage = false;
+
+                while (!receivedExitMessage)
+                {
+                    /*
+                     * Blocks on the server until a message is available in the
+                     * queue or a brief amount of time has passed. Returns null
+                     * when there are no queued messages.
+                     */
+                    var message = readSession.Read();
+                    receivedExitMessage = HandleMessage(message);
+                }
+
+                /*
+                 * The server will discard any remaining queued messages when
+                 * disposing the session.
+                 */
+                Console.WriteLine("Remaining bytes in the message queue: {0}",
+                    readSession.QueueSize);
+            }
+        }
+
+        private static void PublishMessages(IHttpConfiguration configuration)
+        {
+            /*
+             * Open a separate session for publishing messages. This is not
+             * required, but simulates how two separate applications can
+             * communicate with each other using messages.
+             */
+            Console.WriteLine("Publishing messages...");
+
+            using (var writeSession = MessageSession.Open(configuration))
+            {
+                /*
+                 * Messages can contain any string. It's up to the application
+                 * to determine the data format to use for each message topic.
+                 * In this example, the example.data topic contains a JSON
+                 * representation of the MessageData class.
+                 */
+                var data = JsonConvert.SerializeObject(new MessageData
+                {
+                    Message = "Hello World! PI=",
+                    Value = Math.PI
+                });
+                writeSession.Publish("example.data", data);
+
+                data = JsonConvert.SerializeObject(new MessageData
+                {
+                    Message = "Another message, E=",
+                    Value = Math.E
+                });
+                writeSession.Publish("example.data", data);
+
+                /*
+                 * The server will ignore messages published to a topic with no
+                 * subscribers, but it's not an error.
+                 */
+                writeSession.Publish("example.unknown", "no subscribers");
+
+                /*
+                 * Publish messages to the example.exit topic to signal the
+                 * reader to stop. Both are queued, but only one is read.
+                 */
+                writeSession.Publish("example.exit", "first exit");
+                writeSession.Publish("example.exit", "second exit");
+            }
+        }
+
+        private static bool HandleMessage(MessageWithTopic message)
+        {
+            if (message == null)
+            {
+                Console.WriteLine("Read timed out, trying again");
+                return false;
+            }
+
+            /*
+             * Received a message. Parse the data based on the topic.
+             */
+            switch (message.Topic)
+            {
+                case "example.data":
+                    var data = JsonConvert.DeserializeObject<MessageData>(
+                        message.Message);
+                    Console.WriteLine("Received message {0}{1}",
+                        data.Message, data.Value);
+                    return false;
+
+                case "example.exit":
+                    Console.WriteLine("Received exit message {0}",
+                        message.Message);
+                    return true;
+
+                default:
+                    Console.Error.WriteLine("Unexpected message topic {0}",
+                        message.Topic);
+                    return false;
+            }
+        }
+
+        private class MessageData
+        {
+            public string Message { get; set; }
+            public double Value { get; set; }
+        }
+    }
+}

--- a/examples/message/send_receive/SendReceive.csproj
+++ b/examples/message/send_receive/SendReceive.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../../ExampleConfiguration.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.2" />
+    <PackageReference Include="NationalInstruments.SystemLink.Clients.Message" Version="1.0.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a basic message API example for sending and receiving messages.

### Why should this Pull Request be merged?

Helps users get started with the message API.

### What testing has been done?

Ran the example locally against SystemLink Cloud. Sample output:

```
Opening message read session...
Publishing messages...
Message queue size: 138 of 1048576 bytes
Reading back messages...
Received message Hello World! PI=3.14159265358979
Received message Another message, E=2.71828182845905
Received exit message first exit
Remaining bytes in the message queue: 11
```
README previews:
- [examples](https://github.com/ni/systemlink-client-docs/tree/users/pspangle/message-example/examples)
- [examples/message](https://github.com/ni/systemlink-client-docs/tree/users/pspangle/message-example/examples/message)
- [examples/message/send_receive](https://github.com/ni/systemlink-client-docs/tree/users/pspangle/message-example/examples/message/send_receive)