### PR TITLE
Add example that integrates into a LabVIEW message example

### DIFF
--- a/examples/ExampleConfiguration.cs
+++ b/examples/ExampleConfiguration.cs
@@ -18,99 +18,135 @@ namespace NationalInstruments.SystemLink.Clients.Examples
         /// configuration. Exits if a suitable configuration is not available.
         /// </summary>
         /// <param name="args">The arguments used to run the example.</param>
+        /// <param name="allowCloud">Whether the example supports SystemLink
+        /// Cloud or not. When true (default), the --cloud argument may be used
+        /// to run the example with SystemLink Cloud. When false, the --cloud
+        /// argument will produce an error.</param>
         /// <returns>A configuration to use for the example.</returns>
-        public static IHttpConfiguration Obtain(string[] args)
+        public static IHttpConfiguration Obtain(
+            string[] args,
+            bool allowCloud = true)
         {
-            if (args?.Length > 0)
+            return new Parser(allowCloud).Parse(args);
+        }
+
+        private class Parser
+        {
+            private readonly bool _allowCloud;
+
+            public Parser(bool allowCloud)
             {
-                switch (args[0])
+                _allowCloud = allowCloud;
+            }
+
+            public IHttpConfiguration Parse(string[] args)
+            {
+                if (args?.Length > 0)
                 {
-                    case "--cloud":
-                        return ObtainCloudOrExit(args);
-                    case "--server":
-                        return ObtainServerOrExit(args);
-                    case "--help":
-                        return PrintUsageAndExit(string.Empty);
-                    default:
-                        return PrintUsageAndExit("Invalid argument " + args[0]);
+                    switch (args[0])
+                    {
+                        case "--cloud":
+                            return ObtainCloudOrExit(args);
+                        case "--server":
+                            return ObtainServerOrExit(args);
+                        case "--help":
+                            return PrintUsageAndExit(string.Empty);
+                        default:
+                            return PrintUsageAndExit(
+                                "Invalid argument " + args[0]);
+                    }
+                }
+                else
+                {
+                    return ObtainDefaultOrExit();
                 }
             }
-            else
-            {
-                return ObtainDefaultOrExit();
-            }
-        }
 
-        private static IHttpConfiguration ObtainCloudOrExit(string[] args)
-        {
-            if (args.Length != 2)
+            private IHttpConfiguration ObtainCloudOrExit(string[] args)
             {
-                return PrintUsageAndExit("--cloud requires 1 API key argument");
-            }
-
-            return new CloudHttpConfiguration(args[1]);
-        }
-
-        private static IHttpConfiguration ObtainDefaultOrExit()
-        {
-            try
-            {
-                var manager = new HttpConfigurationManager();
-                return manager.GetConfiguration();
-            }
-            catch (ApiException ex)
-            {
-                return PrintUsageAndExit(ex.Message);
-            }
-        }
-
-        private static IHttpConfiguration ObtainServerOrExit(string[] args)
-        {
-            try
-            {
-                switch (args.Length)
+                if (!_allowCloud)
                 {
-                    case 1:
-                        return PrintUsageAndExit("--server requires URL and optional username and password");
+                    return PrintUsageAndExit("This example does not support SystemLink Cloud");
+                }
 
-                    case 2:
-                        return new HttpConfiguration(new Uri(args[1]));
+                if (args.Length != 2)
+                {
+                    return PrintUsageAndExit(
+                        "--cloud requires 1 API key argument");
+                }
 
-                    case 3:
-                        return PrintUsageAndExit("--server requires password when specifying a username");
+                return new CloudHttpConfiguration(args[1]);
+            }
 
-                    case 4:
-                        return new HttpConfiguration(new Uri(args[1]), args[2], args[3]);
-
-                    default:
-                        return PrintUsageAndExit("--server does not take more arguments than URL, username, and password");
+            private IHttpConfiguration ObtainDefaultOrExit()
+            {
+                try
+                {
+                    var manager = new HttpConfigurationManager();
+                    return manager.GetConfiguration();
+                }
+                catch (ApiException ex)
+                {
+                    return PrintUsageAndExit(ex.Message);
                 }
             }
-            catch (FormatException ex)
-            {
-                return PrintUsageAndExit("Invalid URL for --server: " + ex.Message);
-            }
-        }
 
-        private static IHttpConfiguration PrintUsageAndExit(string error)
-        {
-            Console.Error.WriteLine("This example requires a configuration.");
-            Console.Error.WriteLine(error);
-            Console.Error.WriteLine();
-            Console.Error.WriteLine("When running on a machine with SystemLink Server installed or on a system");
-            Console.Error.WriteLine("managed by a SystemLink Server, do not specify any arguments. Otherwise,");
-            Console.Error.WriteLine("specify a configuration using one of the following arguments:");
-            Console.Error.WriteLine();
-            Console.Error.WriteLine("\t--cloud <api_key>");
-            Console.Error.WriteLine("\t--server <url> [<username> <password>]");
-            Console.Error.WriteLine();
-            Console.Error.WriteLine("Generate an API key on SystemLink Cloud. Go to https://www.systemlinkcloud.com,");
-            Console.Error.WriteLine("log in with your NI User Account, and click Security to create an API key. To");
-            Console.Error.WriteLine("run the example against a SystemLink Server, the URL should include the scheme,");
-            Console.Error.WriteLine("host, and port if not default. For example:");
-            Console.Error.WriteLine("dotnet run -- --server https://myserver:9091 admin my_password");
-            Environment.Exit(1);
-            return null;
+            private IHttpConfiguration ObtainServerOrExit(string[] args)
+            {
+                try
+                {
+                    switch (args.Length)
+                    {
+                        case 1:
+                            return PrintUsageAndExit("--server requires URL and optional username and password");
+
+                        case 2:
+                            return new HttpConfiguration(new Uri(args[1]));
+
+                        case 3:
+                            return PrintUsageAndExit("--server requires password when specifying a username");
+
+                        case 4:
+                            return new HttpConfiguration(
+                                new Uri(args[1]), args[2], args[3]);
+
+                        default:
+                            return PrintUsageAndExit("--server does not take more arguments than URL, username, and password");
+                    }
+                }
+                catch (FormatException ex)
+                {
+                    return PrintUsageAndExit(
+                        "Invalid URL for --server: " + ex.Message);
+                }
+            }
+
+            private IHttpConfiguration PrintUsageAndExit(string error)
+            {
+                Console.Error.WriteLine("This example requires a configuration.");
+                Console.Error.WriteLine(error);
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("When running on a machine with SystemLink Server installed or on a system");
+                Console.Error.WriteLine("managed by a SystemLink Server, do not specify any arguments. Otherwise,");
+                Console.Error.WriteLine("specify a configuration using one of the following arguments:");
+                Console.Error.WriteLine();
+                if (_allowCloud)
+                {
+                    Console.Error.WriteLine("\t--cloud <api_key>");
+                }
+                Console.Error.WriteLine("\t--server <url> [<username> <password>]");
+                Console.Error.WriteLine();
+                if (_allowCloud)
+                {
+                    Console.Error.WriteLine("Generate an API key on SystemLink Cloud. Go to https://www.systemlinkcloud.com,");
+                    Console.Error.WriteLine("log in with your NI User Account, and click Security to create an API key.");
+                }
+                Console.Error.WriteLine("To run the example against a SystemLink Server, the URL should include the");
+                Console.Error.WriteLine("scheme, host, and port if not default. For example:");
+                Console.Error.WriteLine("dotnet run -- --server https://myserver:9091 admin my_password");
+                Environment.Exit(1);
+                return null;
+            }
         }
     }
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,7 +40,7 @@ API Examples
 ### [Message](message)
 
 - [Send and Receive](message/send_receive): Demonstrates how to use the
-  SystemLink Message Client API to send and receive messages between sessions
+  SystemLink Message Client API to send and receive messages between sessions.
 - [LabVIEW Async](message/labview): Demonstrates how to use the SystemLink Message
   Client API to asynchronously send and receive messages as part of the
   Async Messaging LabVIEW example.

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,3 +41,6 @@ API Examples
 
 - [Send and Receive](message/send_receive): Demonstrates how to use the
   SystemLink Message Client API to send and receive messages between sessions
+- [LabVIEW Async](message/labview): Demonstrates how to use the SystemLink Message
+  Client API to asynchronously send and receive messages as part of the
+  Async Messaging LabVIEW example.

--- a/examples/message/README.md
+++ b/examples/message/README.md
@@ -33,3 +33,6 @@ Message Examples
 
 - [Send and Receive](send_receive): Demonstrates how to use the
   SystemLink Message Client API to send and receive messages between sessions
+- [LabVIEW Async](labview): Demonstrates how to use the SystemLink Message
+  Client API to asynchronously send and receive messages as part of the
+  Async Messaging LabVIEW example.

--- a/examples/message/labview/LabVIEW.cs
+++ b/examples/message/labview/LabVIEW.cs
@@ -28,7 +28,7 @@ namespace NationalInstruments.SystemLink.Clients.Examples.Message
              * See the configuration example for how a typical application
              * might obtain a configuration.
              */
-            var configuration = ExampleConfiguration.Obtain(args);
+            var configuration = ExampleConfiguration.Obtain(args, allowCloud: false);
 
             /*
              * Open a session and subscribe to a topic. Once subscribed, the

--- a/examples/message/labview/LabVIEW.cs
+++ b/examples/message/labview/LabVIEW.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using NationalInstruments.SystemLink.Clients.Message;
+
+namespace NationalInstruments.SystemLink.Clients.Examples.Message
+{
+    /// <summary>
+    /// Example for the SystemLink Message client API that communicates with
+    /// Host.vi from the Async Messaging LabVIEW example.
+    /// </summary>
+    class LabVIEW
+    {
+        /// <summary>
+        /// The delay between sending periodic messages to the host topic.
+        /// </summary>
+        static readonly TimeSpan MessageDelay = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        /// The message topic for sending messages to the Host VI.
+        /// </summary>
+        const string HostTopic = "Example to Host";
+
+        static void Main(string[] args)
+        {
+            /*
+             * See the configuration example for how a typical application
+             * might obtain a configuration.
+             */
+            var configuration = ExampleConfiguration.Obtain(args);
+
+            /*
+             * Open a session and subscribe to a topic. Once subscribed, the
+             * server will begin to queue messages published by Host.vi.
+             */
+            Console.WriteLine("Opening message session...");
+            int messagesSent;
+            int messagesReceived;
+
+            using (var session = MessageSession.Open(configuration))
+            using (var exitSource = new CancellationTokenSource())
+            {
+                session.Subscribe("Example to Client");
+
+                /*
+                 * Set up a CancelKeyPress handler to clean up the session
+                 * when pressing Ctrl+C to stop the example. The handler will
+                 * cancel our CancellationTokenSource, signalling our async
+                 * loops to stop.
+                 */
+                Console.CancelKeyPress += (s, e) =>
+                {
+                    if (e.SpecialKey == ConsoleSpecialKey.ControlBreak)
+                    {
+                        // Allow Ctrl+Break to terminate the process.
+                        return;
+                    }
+
+                    exitSource.Cancel();
+                    Console.WriteLine("Stopping...");
+                    e.Cancel = true;
+                };
+
+                /*
+                 * Begin asynchronous tasks to read and publish messages until
+                 * the token is canceled, then wait for the tasks to complete.
+                 */
+                var mainLoopTask = RunLoopsAsync(session, exitSource.Token);
+                (messagesSent, messagesReceived) = mainLoopTask.Result;
+            }
+
+            Console.WriteLine("Message session closed");
+            Console.WriteLine("Published {0} and received {1} messages",
+                messagesSent, messagesReceived);
+        }
+
+        /// <summary>
+        /// Asynchronously performs the examples tasks in a loop until the
+        /// <paramref name="token"/> is canceled.
+        /// </summary>
+        /// <returns>
+        /// A task that when complete contains a tuple with the number of
+        /// messages published and the number of messages received in total.
+        /// </returns>
+        static async Task<(int messagesSent, int messagesReceived)> RunLoopsAsync(
+            IQueuedMessageSession session,
+            CancellationToken token)
+        {
+            Console.WriteLine("Run Host.vi to send and receive messages from this example.");
+            Console.WriteLine("Press Ctrl+C to stop.");
+            Console.WriteLine();
+
+            /*
+             * Begin each loop and wait for both to complete.
+             */
+            var publishLoop = PublishLoopAsync(session, token);
+            var readLoop = ReadMessageLoopAsync(session, token);
+            await Task.WhenAll(publishLoop, readLoop).ConfigureAwait(false);
+            return (publishLoop.Result, readLoop.Result);
+        }
+
+        /// <summary>
+        /// Asynchronously publishes messages to Host.vi with a
+        /// <see cref="MessageDelay"/> delay before each message until the
+        /// <paramref name="token"/> is canceled.
+        /// </summary>
+        /// <returns>A task that when complete contains the number of messages
+        /// published by the loop.</returns>
+        static async Task<int> PublishLoopAsync(IMessageSession session, CancellationToken token)
+        {
+            int messagesSent = 0;
+
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(MessageDelay, token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Return when the token is canceled during the delay.
+                    break;
+                }
+
+                var message = DateTime.Now.ToString(CultureInfo.CurrentCulture);
+                await session.PublishAsync(HostTopic, message).ConfigureAwait(false);
+                ++messagesSent;
+            }
+
+            return messagesSent;
+        }
+
+        /// <summary>
+        /// Asynchronously reads messages from Host.vi until
+        /// <paramref name="token"/> is canceled.
+        /// </summary>
+        /// <returns>A task that when complete contains the number of messages
+        /// read by the loop.</returns>
+        static async Task<int> ReadMessageLoopAsync(IQueuedMessageSession session, CancellationToken token)
+        {
+            int messagesReceived = 0;
+
+            while (!token.IsCancellationRequested)
+            {
+                /*
+                 * Try to read a message if one is available. The timeout
+                 * determines the responsiveness of stopping the example,
+                 * because we wait for the read to complete before returning.
+                 */
+                var message = await session.ReadAsync(timeoutMilliseconds: 2000)
+                    .ConfigureAwait(false);
+
+                if (message == null)
+                {
+                    // No message has been queued, so loop around to read again.
+                    continue;
+                }
+
+                ++messagesReceived;
+                var date = DateTime.Now.ToString("d", CultureInfo.CurrentCulture);
+                var time = DateTime.Now.ToString("T", CultureInfo.CurrentCulture);
+
+                Console.WriteLine("Received message:");
+                Console.WriteLine("\tDate: {0}", date);
+                Console.WriteLine("\tTime: {0}", time);
+                Console.WriteLine("\tTopic: {0}", message.Topic);
+                Console.WriteLine("\tMessage: {0}", message.Message);
+                Console.WriteLine();
+
+                /*
+                 * Send a message back to the host to indicate we received
+                 * the message. The reply is sent using a different topic than
+                 * the one on which we received the message.
+                 */
+                await session.PublishAsync(HostTopic,
+                    "Replying to " + message.Message).ConfigureAwait(false);
+            }
+
+            return messagesReceived;
+        }
+    }
+}

--- a/examples/message/labview/LabVIEW.cs
+++ b/examples/message/labview/LabVIEW.cs
@@ -7,8 +7,8 @@ using NationalInstruments.SystemLink.Clients.Message;
 namespace NationalInstruments.SystemLink.Clients.Examples.Message
 {
     /// <summary>
-    /// Example for the SystemLink Message client API that communicates with
-    /// Host.vi from the Async Messaging LabVIEW example.
+    /// Example for the SystemLink Message Client API that communicates with
+    /// the Host.vi from the Async Messaging LabVIEW example.
     /// </summary>
     class LabVIEW
     {

--- a/examples/message/labview/README.md
+++ b/examples/message/labview/README.md
@@ -1,0 +1,66 @@
+Message LabVIEW Async Example
+=============================
+
+This is an example console application demonstrating how to use the SystemLink
+Message Client API to asynchronously send and receive messages as part of the
+Async Messaging LabVIEW example.
+
+Additional message Client examples are available in the
+[root message examples directory](..).
+
+Running the Example
+-------------------
+
+This example is designed to run in conjunction with a LabVIEW example. Because
+the LabVIEW example uses AMQP, it does not support SystemLink Cloud. For best
+results, do not run this example with the --cloud argument.
+
+1. Install the SystemLink Client from NI Package Manager to add SystemLink
+   message support to LabVIEW.
+2. Download and extract the [repository source](https://github.com/ni/systemlink-client-docs/archive/master.zip).
+3. Install the [.NET Core SDK](https://dotnet.microsoft.com/download/dotnet-core).
+4. Navigate to the example's directory and use the [`dotnet run` command](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-run?tabs=netcore21).
+5. From the LabVIEW help menu, select Find Examples to open NI Example Finder.
+   On the Search tab, search for messaging and open `Async Messaging.lvproj`.
+6. Open and run `Host.vi` under My Computer to interact with the running example.
+7. When finished, stop the VI and use Control+C to stop the dotnet command.
+
+To run the example with a different configuration, use one of the following
+commands instead:
+
+```
+dotnet run -- --cloud <api_key>
+dotnet run -- --server <url> <username> <password>
+```
+
+For example: `dotnet run -- --server https://my_server admin "my password"`.
+
+### Sample output
+
+```
+Opening message session...
+Run Host.vi to send and receive messages from this example.
+Press Ctrl+C to stop.
+
+Received message:
+        Date: 5/16/2019
+        Time: 4:22:17 PM
+        Topic: Example to Client
+        Message: This is a message sent from LabVIEW
+
+Stopping...
+Message session closed
+Published 8 and received 1 messages
+```
+
+About the Example
+-----------------
+
+This example creates a message session and subscribes to receive messages sent
+by the LabVIEW Host VI. Additionally, the example publishes a message every
+second that the Host VI receives and displays in the Received Messages list.
+This demonstrates how separate applications connected to the same SystemLink
+Server or SystemLink Cloud instance can communicate with each other.
+
+See the [Message Send and Receive example](../send_receive) for more information
+about using the SystemLink Message Client API and related concepts.

--- a/examples/message/labview/README.md
+++ b/examples/message/labview/README.md
@@ -5,7 +5,7 @@ This is an example console application demonstrating how to use the SystemLink
 Message Client API to asynchronously send and receive messages as part of the
 Async Messaging LabVIEW example.
 
-Additional message Client examples are available in the
+Additional Message Client examples are available in the
 [root message examples directory](..).
 
 Running the Example
@@ -16,7 +16,7 @@ the LabVIEW example uses AMQP, it does not support SystemLink Cloud. For best
 results, do not run this example with the --cloud argument.
 
 1. Install the SystemLink Client from NI Package Manager to add SystemLink
-   message support to LabVIEW.
+   Message support to LabVIEW.
 2. Download and extract the [repository source](https://github.com/ni/systemlink-client-docs/archive/master.zip).
 3. Install the [.NET Core SDK](https://dotnet.microsoft.com/download/dotnet-core).
 4. Navigate to the example's directory and use the [`dotnet run` command](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-run?tabs=netcore21).

--- a/examples/message/labview/README.md
+++ b/examples/message/labview/README.md
@@ -12,8 +12,8 @@ Running the Example
 -------------------
 
 This example is designed to run in conjunction with a LabVIEW example. Because
-the LabVIEW example uses AMQP, it does not support SystemLink Cloud. For best
-results, do not run this example with the --cloud argument.
+the LabVIEW example uses AMQP, it does not support SystemLink Cloud. As such,
+do not run this example with the --cloud argument.
 
 1. Install the SystemLink Client from NI Package Manager to add SystemLink
    Message support to LabVIEW.
@@ -25,11 +25,10 @@ results, do not run this example with the --cloud argument.
 6. Open and run `Host.vi` under My Computer to interact with the running example.
 7. When finished, stop the VI and use Control+C to stop the dotnet command.
 
-To run the example with a different configuration, use one of the following
-commands instead:
+To run the example with a different configuration, use a command like the
+following instead:
 
 ```
-dotnet run -- --cloud <api_key>
 dotnet run -- --server <url> <username> <password>
 ```
 

--- a/examples/message/labview/labview.csproj
+++ b/examples/message/labview/labview.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../../ExampleConfiguration.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.2" />
+    <PackageReference Include="NationalInstruments.SystemLink.Clients.Message" Version="1.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/examples/message/send_receive/SendReceive.cs
+++ b/examples/message/send_receive/SendReceive.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 namespace NationalInstruments.SystemLink.Clients.Examples.Message
 {
     /// <summary>
-    /// Example for the SystemLink Message client API that opens two message
+    /// Example for the SystemLink Message Client API that opens two message
     /// sessions, sends JSON messages from one, and then reads those messages
     /// back from the other.
     /// </summary>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a second message client example using asynchronous APIs to communicate with the LabVIEW Async Messaging example project.

### Why should this Pull Request be merged?

Helps users see how different applications can use the message API to communicate with one another.

### What testing has been done?

Ran the LabVIEW example and the C# example and verified they work as expected. Neither errors when the other isn't running, there just isn't any communication going on.

[Message examples README Preview](https://github.com/ni/systemlink-client-docs/tree/users/pspangle/message-lv-example/examples/message)
[LV example README Preview](https://github.com/ni/systemlink-client-docs/tree/users/pspangle/message-lv-example/examples/message/labview)