### PR TITLE
Add a tag example for subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ namespace GettingStarted
             var apiKey = args[0]; // Not a secure way to load an API key.
             var config = new CloudHttpConfiguration(apiKey);
 
-            using (var manager = new HttpTagManager(config))
+            using (var manager = new TagManager(config))
             using (var writer = manager.CreateWriter(maxBufferTime: TimeSpan.FromSeconds(1)))
             {
                 var tag = manager.Open("example.gettingstarted.double", DataType.Double);
@@ -81,4 +81,5 @@ namespace GettingStarted
 
 ## Documentation
 
-See the [Wiki](https://github.com/ni/systemlink-client-docs/wiki) for each client API's documentation.
+See the [Wiki](https://github.com/ni/systemlink-client-docs/wiki) for each
+client APIs' documentation.

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,3 +49,5 @@ API Examples
 
 - [Query](tag/query): Demonstrates how to use the SystemLink Tag services API to
   query for tags by properties to retrieve metadata for each tag.
+- [Subscription](subscription): Demonstrates how to use the SystemLink Tag API
+  to receive notifications when tag values change.

--- a/examples/tag/README.md
+++ b/examples/tag/README.md
@@ -33,3 +33,5 @@ Tag Examples
 
 - [Query](query): Demonstrates how to use the SystemLink Tag API to query for
   tags by properties to retrieve metadata for each tag.
+- [Subscription](subscription): Demonstrates how to use the SystemLink Tag API
+  to receive notifications when tag values change.

--- a/examples/tag/query/README.md
+++ b/examples/tag/query/README.md
@@ -5,7 +5,7 @@ This is a simple example console application demonstrating how to use the
 SystemLink Tag API to query for tags by properties to retrieve metadata for
 each tag.
 
-Additional tag Client examples are available in the [root tag examples directory](..).
+Additional Tag Client examples are available in the [root tag examples directory](..).
 
 Running the Example
 -------------------

--- a/examples/tag/subscription/README.md
+++ b/examples/tag/subscription/README.md
@@ -4,7 +4,7 @@ Tag Subscription Example
 This is a simple example console application demonstrating how to use the
 SystemLink Tag API to receive notifications when tag values change.
 
-Additional tag Client examples are available in the [root tag examples directory](..).
+Additional Tag Client examples are available in the [root tag examples directory](..).
 
 Running the Example
 -------------------
@@ -54,12 +54,13 @@ Similarly, tag value writes are buffered using the `CreateWriter` method.
 
 ### Selections
 
-The Tag API enables grouping sets of tags using a selection. These selections
-group tags based on path, whether by a full path such as `example.subscription.double`
-or a wildcard path such as `example.subscription.*`. Selections are also another
-way of performing bulk operations such as reading the values or metadata for
-all tags that match the selection's paths. Finally, selections provide a means
-to create a tag subscription, which is the focus of this example.
+If you want to group sets of tags, use a selection. A selection groups tags
+based on the path(s) provided, such as an exact tag path
+(e.g. `example.subscription.double`) or with a wildcard path
+(e.g. `example.subscription.*`). Selections are also another way of performing
+bulk operations, such as reading the values or metadata for all tags that match
+the selection's paths. Finally, selections provide a means to create a tag
+subscription, which is the focus of this example.
 
 See the separate [tag selection](../selection) example for more information
 about the uses of selections.

--- a/examples/tag/subscription/README.md
+++ b/examples/tag/subscription/README.md
@@ -1,0 +1,75 @@
+Tag Subscription Example
+========================
+
+This is a simple example console application demonstrating how to use the
+SystemLink Tag API to receive notifications when tag values change.
+
+Additional tag Client examples are available in the [root tag examples directory](..).
+
+Running the Example
+-------------------
+
+1. Download and extract the [repository source](https://github.com/ni/systemlink-client-docs/archive/master.zip).
+2. Install the [.NET Core SDK](https://dotnet.microsoft.com/download/dotnet-core).
+3. Navigate to the example's directory and use the [`dotnet run` command](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-run?tabs=netcore21).
+
+To run the example with a different configuration, use one of the following
+commands instead:
+
+```
+dotnet run -- --cloud <api_key>
+dotnet run -- --server <url> <username> <password>
+```
+
+For example: `dotnet run -- --server https://my_server admin "my password"`.
+
+### Sample output
+
+```
+Creating example tags...
+Subscribing to tag value changes...
+Writing tag values (1/2)...
+[subscription] example.subscription.double value changed to 3.14159265358979
+[subscription] example.subscription.int value changed to 3
+Writing tag values (2/2)...
+[subscription] example.subscription.double value changed to 12.123
+[subscription] example.subscription.int value changed to 12
+Unsubscribing...
+Deleting example tags...
+```
+
+About the Example
+-----------------
+
+This example creates a Double tag and an Int32 tag. It then subscribes to value
+changes for both tags. Finally, it writes values to each tag and waits for the
+subscription to send the value change notifications.
+
+### Bulk Operations
+
+The Tag API enables creating tags individually via the `Open` method, or in bulk
+using the `Update` method. In general, applications should use bulk operations
+whenever possible to reduce the number of requests made to the server.
+Similarly, tag value writes are buffered using the `CreateWriter` method.
+
+### Selections
+
+The Tag API enables grouping sets of tags using a selection. These selections
+group tags based on path, whether by a full path such as `example.subscription.double`
+or a wildcard path such as `example.subscription.*`. Selections are also another
+way of performing bulk operations such as reading the values or metadata for
+all tags that match the selection's paths. Finally, selections provide a means
+to create a tag subscription, which is the focus of this example.
+
+See the separate [tag selection](../selection) example for more information
+about the uses of selections.
+
+### Subscriptions
+
+Tag subscriptions monitor all tags within a selection for value changes. Unlike
+selections that dynamically update as tags are created and deleted, the set of
+tags monitored by a subscription is fixed at creation time. `TagChanged` events
+are raised periodically on the thread pool when the values of monitored tags
+change on the server. The event contains information about the tag and its new
+value. When a single tag's value changes multiple times between `TagChanged`
+events, only a single event is raised containing the most recent value.

--- a/examples/tag/subscription/Subscription.cs
+++ b/examples/tag/subscription/Subscription.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Threading;
+using NationalInstruments.SystemLink.Clients.Tag;
+using NationalInstruments.SystemLink.Clients.Tag.Values;
+
+namespace NationalInstruments.SystemLink.Clients.Examples.Tag
+{
+    /// <summary>
+    /// Example for the SystemLink Tag client API that uses a subscription to
+    /// receive tag value updates.
+    /// </summary>
+    class Subscription
+    {
+        /// <summary>
+        /// The number of tags created for the example.
+        /// </summary>
+        private const int NumTags = 2;
+
+        static void Main(string[] args)
+        {
+            /*
+             * See the configuration example for how a typical application
+             * might obtain a configuration.
+             */
+            var configuration = ExampleConfiguration.Obtain(args);
+
+            /*
+             * Create the TagManager for communicating with the server and the
+             * tag writer for sending tag values to the server.
+             */
+            using (var manager = new TagManager(configuration))
+            using (var writer = manager.CreateWriter(NumTags * 2))
+            {
+                /*
+                 * Create two tags, one a double and the other an int.
+                 * Using Update enables creating both tags in a single API call.
+                 */
+                var doubleTag = new TagData("example.subscription.double",
+                    DataType.Double);
+                var intTag = new TagData("example.subscription.int",
+                    DataType.Int32);
+                Console.WriteLine("Creating example tags...");
+                manager.Update(new[] { doubleTag, intTag });
+
+                var doubleWriter = new DoubleTagValueWriter(writer, doubleTag);
+                var intWriter = new Int32TagValueWriter(writer, intTag);
+
+                using (var selection = manager.CreateSelection(doubleTag, intTag))
+                {
+                    try
+                    {
+                        /*
+                         * Subscribe to receive events when the tags' current
+                         * values change.
+                         */
+                        Console.WriteLine("Subscribing to tag value changes...");
+                        using (var subscription = selection.CreateSubscription())
+                        using (var handler = new TagChangedHandler(subscription))
+                        {
+                            /*
+                             * Write to each tag and send them to the server.
+                             */
+                            Console.WriteLine("Writing tag values (1/2)...");
+                            doubleWriter.Write(Math.PI);
+                            intWriter.Write((int)Math.PI);
+                            writer.SendBufferedWrites();
+
+                            /*
+                            * Wait for our subscription to receive each value.
+                            * There may be a delay between the value changing
+                            * on the server and the event firing.
+                            */
+                            if (!handler.WaitForNotifications(NumTags,
+                                TimeSpan.FromSeconds(10)))
+                            {
+                                Console.WriteLine("Did not receive all tag writes");
+                                return;
+                            }
+
+                            /*
+                             * Subscriptions only receive the latest value when
+                             * multiple writes to the same tag occur in a short
+                             * amount of time.
+                             */
+                            Console.WriteLine("Writing tag values (2/2)...");
+                            doubleWriter.Write(Math.E);
+                            doubleWriter.Write(12.123);
+                            intWriter.Write((int)Math.E);
+                            intWriter.Write(12);
+                            // Writes are sent automatically due to buffer size.
+
+                            if (!handler.WaitForNotifications(NumTags * 2,
+                                TimeSpan.FromSeconds(10)))
+                            {
+                                Console.WriteLine("Did not receive all tag writes");
+                                return;
+                            }
+
+                            /*
+                             * Disposing of the subscription will unsubscribe.
+                             */
+                            Console.WriteLine("Unsubscribing...");
+                        }
+                    }
+                    finally
+                    {
+                        Console.WriteLine("Deleting example tags...");
+                        selection.DeleteTagsFromServer();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Contains a handler for <see cref="ITagSubscription.TagChanged"/>
+        /// events.
+        /// </summary>
+        private sealed class TagChangedHandler : IDisposable
+        {
+            private int _receivedEvents;
+            private readonly object _lock;
+            private readonly ITagSubscription _subscription;
+
+            /// <summary>
+            /// Initializes a <see cref="ITagSubscription.TagChanged"/> handler.
+            /// </summary>
+            public TagChangedHandler(ITagSubscription subscription)
+            {
+                _lock = new object();
+                _subscription = subscription;
+
+                /*
+                 * The TagChanged event will notify us of tag value changes.
+                 */
+                subscription.TagChanged += NotifyTagChanged;
+            }
+
+            /// <summary>
+            /// Waits until <paramref name="number"/> tag change events have
+            /// been handled or <paramref name="timeout"/> time has passed.
+            /// </summary>
+            /// <returns>True if all of the notifications have been received.</returns>
+            public bool WaitForNotifications(int number, TimeSpan timeout)
+            {
+                lock (_lock)
+                {
+                    while (_receivedEvents < number)
+                    {
+                        if (!Monitor.Wait(_lock, timeout))
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            }
+
+            public void Dispose()
+            {
+                _subscription.TagChanged -= NotifyTagChanged;
+            }
+
+            /// <summary>
+            /// The subscription calls this method whenever a subscribed tag's
+            /// current value changes.
+            /// </summary>
+            private void NotifyTagChanged(object sender, TagChangedEventArgs args)
+            {
+                switch (args.Tag.DataType)
+                {
+                case DataType.Double:
+                    Console.WriteLine("[subscription] {0} value changed to {1}",
+                        args.Tag.Path, args.DoubleValue.Read());
+                    break;
+
+                case DataType.Int32:
+                    Console.WriteLine("[subscription] {0} value changed to {1}",
+                        args.Tag.Path, args.Int32Value.Read());
+                    break;
+
+                default:
+                    Console.WriteLine("[subscription] Unexpected {0} of type {1}",
+                        args.Tag.Path, args.Tag.DataType);
+                    break;
+                }
+
+                lock (_lock)
+                {
+                    ++_receivedEvents;
+                    Monitor.PulseAll(_lock);
+                }
+            }
+        }
+    }
+}

--- a/examples/tag/subscription/Subscription.cs
+++ b/examples/tag/subscription/Subscription.cs
@@ -32,7 +32,7 @@ namespace NationalInstruments.SystemLink.Clients.Examples.Tag
             using (var writer = manager.CreateWriter(NumTags * 2))
             {
                 /*
-                 * Create two tags, one a double and the other an int.
+                 * Create two tags. Make one a double and the other an int.
                  * Using Update enables creating both tags in a single API call.
                  */
                 var doubleTag = new TagData("example.subscription.double",
@@ -50,8 +50,8 @@ namespace NationalInstruments.SystemLink.Clients.Examples.Tag
                     try
                     {
                         /*
-                         * Subscribe to receive events when the tags' current
-                         * values change.
+                         * Subscribe to receive events when the current values
+                         * of the tags change.
                          */
                         Console.WriteLine("Subscribing to tag value changes...");
                         using (var subscription = selection.CreateSubscription())
@@ -80,7 +80,7 @@ namespace NationalInstruments.SystemLink.Clients.Examples.Tag
                             /*
                              * Subscriptions only receive the latest value when
                              * multiple writes to the same tag occur in a short
-                             * amount of time.
+                             * period of time.
                              */
                             Console.WriteLine("Writing tag values (2/2)...");
                             doubleWriter.Write(Math.E);
@@ -130,7 +130,7 @@ namespace NationalInstruments.SystemLink.Clients.Examples.Tag
                 _subscription = subscription;
 
                 /*
-                 * The TagChanged event will notify us of tag value changes.
+                 * The TagChanged event will notify us of changes in tag value.
                  */
                 subscription.TagChanged += NotifyTagChanged;
             }

--- a/examples/tag/subscription/subscription.csproj
+++ b/examples/tag/subscription/subscription.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../../ExampleConfiguration.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.2" />
+    <PackageReference Include="NationalInstruments.SystemLink.Clients.Tag" Version="1.0.1" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a second tag example to show how to use subscriptions to listen for tag value changes.

Also fixes an issue with the getting started example where we're using the wrong class name. The class was renamed prior to 1.0.0 being published.

### Why should this Pull Request be merged?

Helps users learn the recommended use of subscriptions.

### What testing has been done?

Ran the example for SystemLink Server and Cloud. Note that the subscription example README links to a non-existent selection example. That will be the next example to be added and I didn't want to have to remember to go back and add a link to it from the subscription one.

README previews:
[Root](https://github.com/ni/systemlink-client-docs/tree/users/pspangle/tag-sub)
[Examples](https://github.com/ni/systemlink-client-docs/tree/users/pspangle/tag-sub/examples)
[Tag Examples](https://github.com/ni/systemlink-client-docs/tree/users/pspangle/tag-sub/examples/tag)
[Subscription Example](https://github.com/ni/systemlink-client-docs/tree/users/pspangle/tag-sub/examples/tag/subscription)
