### PR TITLE
Update asset management example with published 1.0.0 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ SystemLink service or collection of related services:
 
 | Service | Package name                                   | Package
 |---------|------------------------------------------------|------------------
+| Asset Management | [NationalInstruments.SystemLink.Clients.AssetManagement](https://github.com/ni/systemlink-client-docs/wiki/Asset-Management) | [![NuGet](https://img.shields.io/nuget/v/NationalInstruments.SystemLink.Clients.AssetManagement.svg)](https://www.nuget.org/packages/NationalInstruments.SystemLink.Clients.AssetManagement/)
 | File Ingestion | [NationalInstruments.SystemLink.Clients.File](https://github.com/ni/systemlink-client-docs/wiki/File) | [![NuGet](https://img.shields.io/nuget/v/NationalInstruments.SystemLink.Clients.File.svg)](https://www.nuget.org/packages/NationalInstruments.SystemLink.Clients.File/)
 | Message | [NationalInstruments.SystemLink.Clients.Message](https://github.com/ni/systemlink-client-docs/wiki/Message) | [![NuGet](https://img.shields.io/nuget/v/NationalInstruments.SystemLink.Clients.Message.svg)](https://www.nuget.org/packages/NationalInstruments.SystemLink.Clients.Message/)
 | Tag     | [NationalInstruments.SystemLink.Clients.Tag](https://github.com/ni/systemlink-client-docs/wiki/Tag) | [![NuGet](https://img.shields.io/nuget/v/NationalInstruments.SystemLink.Clients.Tag.svg)](https://www.nuget.org/packages/NationalInstruments.SystemLink.Clients.Tag/)

--- a/examples/asset/utilization/assetUtilization.csproj
+++ b/examples/asset/utilization/assetUtilization.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NationalInstruments.SystemLink.Clients.AssetManagement" Version="1.0.0-CI-20191108-072008" />
+    <PackageReference Include="NationalInstruments.SystemLink.Clients.AssetManagement" Version="1.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a link and badge for the now-published asset management package. Updates the example to reference the released package instead of an internal prerelease one.

### Why should this Pull Request be merged?

Enables discovery of the NuGet from the main README and running the example.

### What testing has been done?

Built the example locally (but did not run it) and verified the [README](https://github.com/ni/systemlink-client-docs/tree/users/pspangle/apm-published) looks correct with working links.
