### PR TITLE
Remove SystemLink Cloud-related references

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Install-Package NationalInstruments.SystemLink.Clients.Tag
 ### Examples
 
 The below getting started example creates a [double tag](https://github.com/ni/systemlink-client-docs/wiki/Tag) on
-[SystemLink Cloud](https://www.systemlinkcloud.com), writes two values to it,
+SystemLink Server, writes two values to it,
 then reads back and outputs the current value. The tag is deleted at the end
 of the example. See the [examples directory](examples) to browse additional
 code examples.
@@ -59,7 +59,8 @@ namespace GettingStarted
         static void Main(string[] args)
         {
             var apiKey = args[0]; // Not a secure way to load an API key.
-            var config = new CloudHttpConfiguration(apiKey);
+            var config = new HttpConfiguration(
+                new Uri("https://myserver"), apiKey);
 
             using (var manager = new TagManager(config))
             using (var writer = manager.CreateWriter(maxBufferTime: TimeSpan.FromSeconds(1)))

--- a/examples/ExampleConfiguration.cs
+++ b/examples/ExampleConfiguration.cs
@@ -18,35 +18,20 @@ namespace NationalInstruments.SystemLink.Clients.Examples
         /// configuration. Exits if a suitable configuration is not available.
         /// </summary>
         /// <param name="args">The arguments used to run the example.</param>
-        /// <param name="allowCloud">Whether the example supports SystemLink
-        /// Cloud or not. When true (default), the --cloud argument may be used
-        /// to run the example with SystemLink Cloud. When false, the --cloud
-        /// argument will produce an error.</param>
         /// <returns>A configuration to use for the example.</returns>
-        public static IHttpConfiguration Obtain(
-            string[] args,
-            bool allowCloud = true)
+        public static IHttpConfiguration Obtain(string[] args)
         {
-            return new Parser(allowCloud).Parse(args);
+            return new Parser().Parse(args);
         }
 
         private class Parser
         {
-            private readonly bool _allowCloud;
-
-            public Parser(bool allowCloud)
-            {
-                _allowCloud = allowCloud;
-            }
-
             public IHttpConfiguration Parse(string[] args)
             {
                 if (args?.Length > 0)
                 {
                     switch (args[0])
                     {
-                        case "--cloud":
-                            return ObtainCloudOrExit(args);
                         case "--server":
                             return ObtainServerOrExit(args);
                         case "--help":
@@ -60,22 +45,6 @@ namespace NationalInstruments.SystemLink.Clients.Examples
                 {
                     return ObtainDefaultOrExit();
                 }
-            }
-
-            private IHttpConfiguration ObtainCloudOrExit(string[] args)
-            {
-                if (!_allowCloud)
-                {
-                    return PrintUsageAndExit("This example does not support SystemLink Cloud");
-                }
-
-                if (args.Length != 2)
-                {
-                    return PrintUsageAndExit(
-                        "--cloud requires 1 API key argument");
-                }
-
-                return new CloudHttpConfiguration(args[1]);
             }
 
             private IHttpConfiguration ObtainDefaultOrExit()
@@ -130,17 +99,8 @@ namespace NationalInstruments.SystemLink.Clients.Examples
                 Console.Error.WriteLine("managed by a SystemLink Server, do not specify any arguments. Otherwise,");
                 Console.Error.WriteLine("specify a configuration using one of the following arguments:");
                 Console.Error.WriteLine();
-                if (_allowCloud)
-                {
-                    Console.Error.WriteLine("\t--cloud <api_key>");
-                }
                 Console.Error.WriteLine("\t--server <url> [<username> <password>]");
                 Console.Error.WriteLine();
-                if (_allowCloud)
-                {
-                    Console.Error.WriteLine("Generate an API key on SystemLink Cloud. Go to https://www.systemlinkcloud.com,");
-                    Console.Error.WriteLine("log in with your NI User Account, and click Security to create an API key.");
-                }
                 Console.Error.WriteLine("To run the example against a SystemLink Server, the URL should include the");
                 Console.Error.WriteLine("scheme, host, and port if not default. For example:");
                 Console.Error.WriteLine("dotnet run -- --server https://myserver:9091 admin my_password");

--- a/examples/configuration/Configuration.cs
+++ b/examples/configuration/Configuration.cs
@@ -48,19 +48,10 @@ namespace NationalInstruments.SystemLink.Clients.Examples.Configuration
              * Ideally, the username and password would be read from the user at
              * run time or from a file rather than checked into source.
              */
-            var serverConfiguration = new HttpConfiguration(
-                new Uri("https://myserver"), "my_user", "my_password");
-
-            /*
-             * To access SystemLink Cloud instead of a SystemLink Server
-             * installation, log into https://www.systemlinkcloud.com and
-             * generate an API key. Then use that API key with the
-             * CloudHttpConfiguration class.
-             *
-             * Ideally, the API key would be read from a file or otherwise
-             * protected rather than checked into source.
-             */
-            var cloudConfiguration = new CloudHttpConfiguration("apikey");
+            var serverConfiguration1 = new HttpConfiguration(
+                new Uri("https://myserver"), "my_user1", "my_password1");
+            var serverConfiguration2 = new HttpConfiguration(
+                new Uri("https://myserver2"), "my_user2", "my_password2");
 
             /*
              * Configurations are shared across all SystemLink client APIs.
@@ -74,10 +65,10 @@ namespace NationalInstruments.SystemLink.Clients.Examples.Configuration
 
             /*
              * Mixing configurations enables applications to synchronize data
-             * across multiple servers and/or SystemLink Cloud.
+             * across multiple servers.
              */
-            using (var cloudManager = new TagManager(cloudConfiguration))
-            using (var serverManager = new TagManager(serverConfiguration))
+            using (var serverManager1 = new TagManager(serverConfiguration1))
+            using (var serverManager2 = new TagManager(serverConfiguration2))
             {
             }
 

--- a/examples/file/stream/Stream.cs
+++ b/examples/file/stream/Stream.cs
@@ -16,7 +16,7 @@ namespace NationalInstruments.SystemLink.Clients.Examples.File
              * See the configuration example for how a typical application
              * might obtain a configuration.
              */
-            var configuration = ExampleConfiguration.Obtain(args, false);
+            var configuration = ExampleConfiguration.Obtain(args);
 
             // Use the FileUploader for communicating with the server.
             var fileUploader = new FileUploader(configuration);

--- a/examples/message/labview/LabVIEW.cs
+++ b/examples/message/labview/LabVIEW.cs
@@ -28,7 +28,7 @@ namespace NationalInstruments.SystemLink.Clients.Examples.Message
              * See the configuration example for how a typical application
              * might obtain a configuration.
              */
-            var configuration = ExampleConfiguration.Obtain(args, allowCloud: false);
+            var configuration = ExampleConfiguration.Obtain(args);
 
             /*
              * Open a session and subscribe to a topic. Once subscribed, the

--- a/examples/testmonitor/file-attachment/FileAttachment.cs
+++ b/examples/testmonitor/file-attachment/FileAttachment.cs
@@ -21,7 +21,7 @@ namespace NationalInstruments.SystemLink.Clients.Examples.TestMonitor
              * See the configuration example for how a typical application
              * might obtain a configuration.
              */
-            var configuration = ExampleConfiguration.Obtain(args, allowCloud: false);
+            var configuration = ExampleConfiguration.Obtain(args);
 
             /*
              * Create the TestDataManager for communicating with the server.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-client-docs/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove references to `CloudHttpConfiguration` from example projects. We've had an SLS C# Clients pipeline fail since it attempts to build projects in this repo, and CloudHttpConfiguration was removed from the Clients library.

EXTRA: Also adapted example in README for SystemLink Server, instead of SystemLink Cloud.

### Why should this Pull Request be merged?

SystemLink Cloud is defunct.

### What testing has been done?

The branch I'm requesting to have merged into ni:master was temporarily linked to the pipeline above, and the build passed.
